### PR TITLE
fix information loss in property test

### DIFF
--- a/src/pfcp_packet.erl
+++ b/src/pfcp_packet.erl
@@ -236,7 +236,7 @@ maybe_bin(<<Bin/binary>>, 1, Len, Pos, IE) ->
 maybe_bin(Bin, Len, IE)
   when is_binary(Bin) andalso byte_size(Bin) =:= Len ->
     <<IE/binary, Bin:Len/bytes>>;
-maybe_bin(undefined, _, IE) ->
+maybe_bin(_, _, IE) ->
     IE.
 
 maybe_len_bin(<<Bin/binary>>, 0, _, _, IE) ->


### PR DESCRIPTION
The test did first encode a message to binary and them check whether
and dec+enc on that binary returned the same binary.
If the initial encode already lost infromation (e.g. due to too small
data type) the dec+enc check would not catch that.
Instead compare the result of an enc+dec test to the original message.