### PR TITLE
Fix edoc generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _checkouts/
 *~
 rebar3
 rebar.lock
+doc

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,8 @@
 %-*-Erlang-*-
 {erl_opts, [debug_info]}.
 
+{edoc_opts, [{preprocess, true}]}.
+
 {deps, [
 	{cut, "1.0.3"}
 ]}.


### PR DESCRIPTION
Fix error:
```sh
$ ./rebar3 edoc
===> Running edoc for pfcplib
/home/pfcplib/src/pfcp_packet.erl: at line 5300: syntax error before: ';'
/home/pfcplib/src/pfcp_packet.erl: If the error is caused by too exotic macro
/home/pfcplib/src/pfcp_packet.erl: definitions or uses of macros, adding option
/home/pfcplib/src/pfcp_packet.erl: {preprocess, true} can help. See also edoc(3).
edoc: skipping source file '/home/git-repo/pfcplib/src/pfcp_packet.erl': {'EXIT',
                                                                                       error}.
```