### PR TITLE
fix encoding of User ID

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,12 @@ pfcplib
 
 Erlang library for encoding and decoding Packet Forwarding Control Protocol (PFCP) frames.
 
+Version 2.1.1 - 24 June 2021
+---------------------------
+
+**Bugfixes** :bug:
+* [#27](https://github.com/travelping/pfcplib/pull/27) fix encoding of User ID
+
 Version 2.1.0 - 3 June 2021
 ---------------------------
 

--- a/test/property_test/pfcplib_prop.erl
+++ b/test/property_test/pfcplib_prop.erl
@@ -229,6 +229,9 @@ binary(Min, Max) ->
 imsi() ->
     binstr_number(7,15).
 
+msisdn() ->
+    binstr_number(7,20).
+
 imei() ->
     binstr_number(15, 15).
 
@@ -1666,7 +1669,7 @@ gen_user_id() ->
     #user_id{
        imsi = oneof(['undefined', imsi()]),
        imei = oneof(['undefined', imei(), imeisv()]),
-       msisdn = oneof(['undefined', binary()]),
+       msisdn = oneof(['undefined', msisdn()]),
        nai = oneof(['undefined', binary()])
       }.
 


### PR DESCRIPTION
The IMEI, IMSI and MSISDN fields need to be tbcd encoded.